### PR TITLE
fix: Resolve problem with others path of bash

### DIFF
--- a/wp-cli.sh
+++ b/wp-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo 'WordPress Installer from WP-CLI by juanmacivico87'
 
 echo 'This is a local development or a production environment??'


### PR DESCRIPTION
This commit resolves errors with script when bash is placed in other directory( e.g: /usr/local/bin in Kde Neon ).

----------

En mi distribución Linux( Kde Neon ), bash está colocado bajo /usr/local/bin, por lo que hace que no funcione el script. Poniendo una cabecera más genérica debería de ir en cualquier distribución linux en incluso en otros sistemas operativos( e.j: Mac ).